### PR TITLE
make one-sided combat possible without units knowing about map

### DIFF
--- a/Project1/Combat.h
+++ b/Project1/Combat.h
@@ -21,10 +21,10 @@ public:
 
 	explicit Combat(Unit& owner);
 
-	void combat(Unit& defender);
+	void combat(Unit& defender, bool can_retaliate=true);
 	bool doesAvoid(Unit& attacker);
 	std::optional<int> strike(Unit& defender);
 	int takeDamage(Damage dealt);
 protected:
-	optional_pair<int> do_combat(Unit& defender);
+	optional_pair<int> do_combat(Unit& defender, bool can_retaliate=true);
 };


### PR DESCRIPTION
I was going to use two functions or a template, but this was just way easier to reason about.
It will behave as if I made no change because of the default argument, but you should change the map to start combat differently.